### PR TITLE
don't @-prefix generated in-repo dep labels

### DIFF
--- a/jvm/resolve.go
+++ b/jvm/resolve.go
@@ -180,10 +180,6 @@ func ResolveJvmSymbols(
 	deps := treeset.NewWithStringComparator()
 
 	addDep := func(dep string) {
-		if dep[0] != '@' {
-			dep = "@" + dep
-		}
-
 		if !jvmConfig.excludedArtifacts.Contains(dep) {
 			forcedDeps := forcedTransitiveDepsForDep(jvmConfig.ForcedTransitiveDeps, dep)
 			deps = deps.Union(forcedDeps)


### PR DESCRIPTION
We have been writing in-repo labels in dependency lists as `@//my/package/label` for quite some time, instead of allowing gazelle to simply write `//my/package/label`. While the former seems more "correct" on the surface as it explicitly denotes the label's repo, this causes issues if the repo in question is a library consumed as an external dependency elsewhere. In such cases, bazel infers the `@` prefix to refer to the main workspace of the consuming repo rather than being relative to the library repo, which results either in build errors from missing dependencies or, worse, the build silently using incorrect dependencies if the referenced label happens to exist.

This removes our hard-coded prefix, allowing gazelle to once again format the label as it sees fit (without the `@` prefix).