### PR TITLE
remove scala.reflect.runtime.universe from default package map

### DIFF
--- a/jvm/constants.go
+++ b/jvm/constants.go
@@ -17,12 +17,9 @@ var (
 	)
 
 	DEFAULT_PACKAGE_MAP = map[string]*treeset.Set{
-		// universe is technically a lazy val and so doesn't show up in the maven install
-		// package mapping, but the common pattern is to import from it as if it were a
-		// source package. We just hardcode it as a special case here.
-		"scala.reflect.runtime.universe": treeset.NewWithStringComparator(
-			"@maven//:org_scala_lang_scala_reflect",
-		),
+		// There is nothing here now, but packages may be added if they would otherwise need
+		// to be handled manually by all users. Settings here are impossible for users to
+		// override however, so this should be done with caution.
 	}
 
 	DEFAULT_FORCED_TRANSITIVE_DEPS = map[string][]string{}


### PR DESCRIPTION
Internally, we list dependencies for `scala-reflect` and `scala-compiler` explicitly in `deps` lists. This is possibly unnecessary and just a holdover from our Pants days however, so we do not want to force this behavior on all users.

The default package map used for 3rdparty jar dependencies is more or less impossible to override, so I am removing a hard-coded resolve mapping for `scala.reflect.runtime.universe` here. If desired, a `# gazelle:resolve scala scala.reflect.runtime.universe @maven//:org_scala_lang_scala_reflect` directive can serve as a replacement

Fixes #10 